### PR TITLE
Bump yacman to 0.9.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "yacman" %}
-{% set version = "0.9.4" %}
+{% set version = "0.9.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e10babf0faa1e77ce35d8d00e6be1aa762aef5db6666db09015ba013a65e5f45
+  sha256: 8a5ab8287a6ad2f26b9726727c256dc5a0eefc297c5427755cc265ed61803faf
 
 build:
   number: 0


### PR DESCRIPTION
## Summary
- Bump version to 0.9.5
- sha256 updated to match PyPI sdist

The previous bot PR (#22) failed due to conda-forge infrastructure migration issues (alma9 docker image), not due to any change in yacman itself. This PR bumps only the version without the infra changes.

@conda-forge-admin, please rerender